### PR TITLE
Fix handling of hostnames with separator

### DIFF
--- a/internal/cmd/ahs.go
+++ b/internal/cmd/ahs.go
@@ -334,6 +334,11 @@ func computeHostnameWithInstanceID(base, separator, instanceID string, length in
 	if len(splitHost) <= 1 {
 		splitIndex = 1
 	}
+	hostnameIncluded := strings.Contains(awsInstanceID, splitHost[len(splitHost)-1])
+	if !hostnameIncluded {
+		splitIndex = len(splitHost)
+	}
+
 	hostnamePrefix := strings.Join(splitHost[:splitIndex], separator)
 	hostname := strings.Join([]string{hostnamePrefix, truncatedID}, separator)
 

--- a/internal/cmd/ahs_test.go
+++ b/internal/cmd/ahs_test.go
@@ -21,6 +21,7 @@ func TestComputeHostnameWithInstanceID(t *testing.T) {
 		{"myhostname-12345", "myhostname-12345", "-", "i-123456789", 5},
 		{"myhostname-123456789", "myhostname-12345", "-", "i-123456789", 100},
 		{"myhostname-123456789", "myhostname-12345", "-", "i-123456789", -1},
+		{"my-host-name-123456789", "my-host-name", "-", "i-123456789", -1},
 		{"my-host-name-12345", "my-host-name-12345", "-", "i-123456789", 5},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Currently a hostname of `my-hostname` and separator `-`, will be updated
to be `my-12345`. This ensures that the hostname will be set to
`my-hostname-12345`