### PR TITLE
Add support for filtering based on instance state.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/stretchr/testify v1.7.2
 	github.com/txn2/txeh v1.3.0
 	github.com/urfave/cli/v2 v2.8.1
-	golang.org/x/exp v0.0.0-20221012211006-4de253d81b95
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/stretchr/testify v1.7.2
 	github.com/txn2/txeh v1.3.0
 	github.com/urfave/cli/v2 v2.8.1
+	golang.org/x/exp v0.0.0-20221012211006-4de253d81b95
 )
 
 require (
@@ -19,6 +20,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/exp v0.0.0-20221012211006-4de253d81b95 h1:sBdrWpxhGDdTAYNqbgBLAR+ULAPPhfgncLr1X0lyWtg=
-golang.org/x/exp v0.0.0-20221012211006-4de253d81b95/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -55,13 +55,15 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/exp v0.0.0-20221012211006-4de253d81b95 h1:sBdrWpxhGDdTAYNqbgBLAR+ULAPPhfgncLr1X0lyWtg=
+golang.org/x/exp v0.0.0-20221012211006-4de253d81b95/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c h1:aFV+BgZ4svzjfabn8ERpuB4JI4N6/rdy1iusx77G3oU=
-golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -114,7 +114,7 @@ func NewApp(version string, start time.Time) (app *cli.App) {
 				&cli.StringFlag{
 					Name:    "valid-instance-states",
 					EnvVars: []string{"AHS_VALID_INSTANCE_STATES"},
-					Usage:   "comma-delimited list selecting which instance states (running, stopped, etc.) are valid when filtering instances to take into account for assigning sequential ids",
+					Usage:   "comma-delimited list selecting which instance states (running, stopped, etc.) are valid when filtering instances to take into account for assigning sequential ids", // nolint
 					Value:   "running",
 				},
 			},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -111,6 +111,12 @@ func NewApp(version string, start time.Time) (app *cli.App) {
 					EnvVars: []string{"AHS_RESPECT_AZS"},
 					Usage:   "if instances are provisioned through an ASG, setting this flag it will get the sequential-ids associated to respective azs", //nolint
 				},
+				&cli.StringFlag{
+					Name:    "valid-instance-states",
+					EnvVars: []string{"AHS_VALID_INSTANCE_STATES"},
+					Usage:   "comma-delimited list selecting which instance states (running, stopped, etc.) are valid when filtering instances to take into account for assigning sequential ids",
+					Value:   "running",
+				},
 			},
 			Action: cmd.ExecWrapper(cmd.Run),
 		},

--- a/internal/cmd/ahs.go
+++ b/internal/cmd/ahs.go
@@ -466,7 +466,7 @@ func (c *Clients) getASGMaxInstances(asgName string) (int, error) {
 	return int(*asg.MaxSize), nil
 }
 
-func (c *Clients) findAvailableSequentialIDPerRegion(instanceGroup, groupTag, sequentialIDTag string, validInstanceStates string) (int, error) {
+func (c *Clients) findAvailableSequentialIDPerRegion(instanceGroup, groupTag, sequentialIDTag string, validInstanceStates string) (int, error) { // nolint
 	log.Debugf("Looking up instances that belong to the same group within the region")
 
 	// TODO: Need to handle pagination or set a default number of MaxItems.
@@ -487,7 +487,7 @@ func (c *Clients) findAvailableSequentialIDPerRegion(instanceGroup, groupTag, se
 	return computeMostAdequateSequentialID(instances, sequentialIDTag, 1, 1, validInstanceStates)
 }
 
-func (c *Clients) findAvailableSequentialIDPerAZ(instanceAZ, instanceGroup, groupTag, sequentialIDTag string, validInstanceStates string) (int, error) {
+func (c *Clients) findAvailableSequentialIDPerAZ(instanceAZ, instanceGroup, groupTag, sequentialIDTag string, validInstanceStates string) (int, error) { // nolint
 	log.Debugf("Looking up how many AZs are configured on the ASG")
 
 	azs, err := c.getASGAZs(instanceGroup)

--- a/internal/cmd/ahs.go
+++ b/internal/cmd/ahs.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -550,7 +548,15 @@ func computeMostAdequateSequentialID(instances *ec2.DescribeInstancesOutput, seq
 
 	for _, reservation := range instances.Reservations {
 		for _, instance := range reservation.Instances {
-			if !slices.Contains(strings.Split(validInstanceStates, ","), *instance.State.Name) {
+			stateFound := false
+
+			for _, state := range strings.Split(validInstanceStates, ",") {
+				if *instance.State.Name == state {
+					stateFound = true
+				}
+			}
+
+			if stateFound != true {
 				continue
 			}
 

--- a/internal/cmd/ahs_test.go
+++ b/internal/cmd/ahs_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,7 +70,7 @@ func TestComputeMostAdequateSequentialID(t *testing.T) {
 		testInput      sequentialInputs
 		expectedResult int
 	}{
-		"only-running-instances-running-filter": {
+		"only-running-instances-running-filter": { // nolint
 			testInput: sequentialInputs{
 				instances: &ec2.DescribeInstancesOutput{
 					NextToken: nil,
@@ -128,7 +127,7 @@ func TestComputeMostAdequateSequentialID(t *testing.T) {
 			},
 			expectedResult: 4,
 		},
-		"only-running-instances-running-stopped-filter": {
+		"only-running-instances-running-stopped-filter": { // nolint
 			testInput: sequentialInputs{
 				instances: &ec2.DescribeInstancesOutput{
 					NextToken: nil,
@@ -185,7 +184,7 @@ func TestComputeMostAdequateSequentialID(t *testing.T) {
 			},
 			expectedResult: 4,
 		},
-		"running-and-stopped-instances-running-filter": {
+		"running-and-stopped-instances-running-filter": { // nolint
 			testInput: sequentialInputs{
 				instances: &ec2.DescribeInstancesOutput{
 					NextToken: nil,
@@ -242,7 +241,7 @@ func TestComputeMostAdequateSequentialID(t *testing.T) {
 			},
 			expectedResult: 2,
 		},
-		"running-and-stopped-instances-running-stopped-filter": {
+		"running-and-stopped-instances-running-stopped-filter": { // nolint
 			testInput: sequentialInputs{
 				instances: &ec2.DescribeInstancesOutput{
 					NextToken: nil,

--- a/internal/cmd/ahs_test.go
+++ b/internal/cmd/ahs_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,6 +14,14 @@ type inputs struct {
 	separator  string
 	instanceID string
 	length     int
+}
+
+type sequentialInputs struct {
+	instances           *ec2.DescribeInstancesOutput
+	sequentialIDTag     string
+	offset              int
+	modulo              int
+	validInstanceStates string
 }
 
 func TestComputeHostnameWithInstanceID(t *testing.T) {
@@ -53,6 +64,256 @@ func TestValidComputeRegionFromAZ(t *testing.T) {
 func TestInvalidComputeRegionFromAZ(t *testing.T) {
 	_, err := computeRegionFromAZ("foo")
 	assert.NotNil(t, err)
+}
+
+func TestComputeMostAdequateSequentialID(t *testing.T) {
+	tests := map[string]struct {
+		testInput      sequentialInputs
+		expectedResult int
+	}{
+		"only-running-instances-running-filter": {
+			testInput: sequentialInputs{
+				instances: &ec2.DescribeInstancesOutput{
+					NextToken: nil,
+					Reservations: []*ec2.Reservation{
+						{
+							Instances: []*ec2.Instance{
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(16),
+										Name: aws.String("running"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("1"),
+										},
+									},
+									InstanceId: aws.String("blah-1"),
+								},
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(16),
+										Name: aws.String("running"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("2"),
+										},
+									},
+									InstanceId: aws.String("blah-2"),
+								},
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(16),
+										Name: aws.String("running"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("3"),
+										},
+									},
+									InstanceId: aws.String("blah-3"),
+								},
+							},
+						},
+					},
+				},
+				sequentialIDTag:     "ahs:instance-id",
+				offset:              1,
+				modulo:              1,
+				validInstanceStates: "running",
+			},
+			expectedResult: 4,
+		},
+		"only-running-instances-running-stopped-filter": {
+			testInput: sequentialInputs{
+				instances: &ec2.DescribeInstancesOutput{
+					NextToken: nil,
+					Reservations: []*ec2.Reservation{
+						{
+							Instances: []*ec2.Instance{
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(16),
+										Name: aws.String("running"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("1"),
+										},
+									},
+									InstanceId: aws.String("blah-1"),
+								},
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(16),
+										Name: aws.String("running"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("2"),
+										},
+									},
+									InstanceId: aws.String("blah-2"),
+								},
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(16),
+										Name: aws.String("running"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("3"),
+										},
+									},
+									InstanceId: aws.String("blah-3"),
+								},
+							},
+						},
+					},
+				},
+				sequentialIDTag:     "ahs:instance-id",
+				offset:              1,
+				modulo:              1,
+				validInstanceStates: "running,stopped",
+			},
+			expectedResult: 4,
+		},
+		"running-and-stopped-instances-running-filter": {
+			testInput: sequentialInputs{
+				instances: &ec2.DescribeInstancesOutput{
+					NextToken: nil,
+					Reservations: []*ec2.Reservation{
+						{
+							Instances: []*ec2.Instance{
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(16),
+										Name: aws.String("running"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("1"),
+										},
+									},
+									InstanceId: aws.String("blah-1"),
+								},
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(80),
+										Name: aws.String("stopped"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("2"),
+										},
+									},
+									InstanceId: aws.String("blah-2"),
+								},
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(80),
+										Name: aws.String("stopped"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("3"),
+										},
+									},
+									InstanceId: aws.String("blah-3"),
+								},
+							},
+						},
+					},
+				},
+				sequentialIDTag:     "ahs:instance-id",
+				offset:              1,
+				modulo:              1,
+				validInstanceStates: "running",
+			},
+			expectedResult: 2,
+		},
+		"running-and-stopped-instances-running-stopped-filter": {
+			testInput: sequentialInputs{
+				instances: &ec2.DescribeInstancesOutput{
+					NextToken: nil,
+					Reservations: []*ec2.Reservation{
+						{
+							Instances: []*ec2.Instance{
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(16),
+										Name: aws.String("running"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("1"),
+										},
+									},
+									InstanceId: aws.String("blah-1"),
+								},
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(80),
+										Name: aws.String("stopped"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("2"),
+										},
+									},
+									InstanceId: aws.String("blah-2"),
+								},
+								{
+									State: &ec2.InstanceState{
+										Code: aws.Int64(80),
+										Name: aws.String("stopped"),
+									},
+									Tags: []*ec2.Tag{
+										{
+											Key:   aws.String("ahs:instance-id"),
+											Value: aws.String("3"),
+										},
+									},
+									InstanceId: aws.String("blah-3"),
+								},
+							},
+						},
+					},
+				},
+				sequentialIDTag:     "ahs:instance-id",
+				offset:              1,
+				modulo:              1,
+				validInstanceStates: "running,stopped",
+			},
+			expectedResult: 4,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			id, err := computeMostAdequateSequentialID(
+				tt.testInput.instances,
+				tt.testInput.sequentialIDTag,
+				tt.testInput.offset,
+				tt.testInput.modulo,
+				tt.testInput.validInstanceStates,
+			)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expectedResult, id)
+		})
+	}
 }
 
 // func TestUpdateHostnameFile(t *testing.T) {


### PR DESCRIPTION
This commit adds support for filtering states other than running when considering the list of valid targets for calculating sequential IDs. The use case this supports is an ASG with a warm pool, where nodes might be stopped temporarily but should still have their hostnames taken into consideration when selecting tags.

I also added tests to cover the function modified and validate that the default use case still works.